### PR TITLE
Batch eval and lm-eval update 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 **/data/instructions/**
 **/data/instructions_hf/**
 **/data/training_mix/**
+*results*
+*logs
+exp-config.yaml

--- a/batch_cancel.py
+++ b/batch_cancel.py
@@ -1,0 +1,19 @@
+import sys
+from openai import OpenAI
+
+def cancel_job(job_id):
+    client = OpenAI()
+    try:
+        response = client.batches.cancel(job_id)
+        print(f"Job {job_id} canceled successfully.")
+    except Exception as e:
+        print(f"Failed to cancel job {job_id}: {str(e)}")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python cancel_job.py <job_id>")
+        sys.exit(1)
+
+    job_id = sys.argv[1]
+    cancel_job(job_id)
+    

--- a/batch_jobs.py
+++ b/batch_jobs.py
@@ -1,0 +1,59 @@
+import requests
+
+def fetch_batches(api_key):
+    """Fetches all batches from the API and returns them as a list."""
+    url = "https://api.openai.com/v1/batches"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    response = requests.get(url, headers=headers)
+    if response.status_code == 200:
+        return response.json().get('data', [])
+    else:
+        print("Failed to fetch batches")
+        return []
+
+def display_batches(batches):
+    """Displays the batches in a numbered list."""
+    print("Select a batch to view details (or 99 to exit):")
+    for index, batch in enumerate(batches):
+        print(f"{index + 1}. Batch ID: {batch['id']}, Status: {batch['status']}")
+    print("99. Exit")
+
+def fetch_batch_details(api_key, batch_id):
+    """Fetches and displays details of a specific batch."""
+    url = f"https://api.openai.com/v1/batches/{batch_id}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    response = requests.get(url, headers=headers)
+    if response.status_code == 200:
+        batch = response.json()
+        print("Batch Details:")
+        print(batch)
+    else:
+        print("Failed to fetch batch details")
+
+import os
+
+def main():
+    API_KEY = os.getenv("OPENAI_API_KEY")  # Fetch API key from environment variable
+    if API_KEY is None:
+        print("Error: OPENAI_API_KEY environment variable not set.")
+        return
+
+    while True:
+        batches = fetch_batches(API_KEY)
+        display_batches(batches)
+        
+        try:
+            choice = int(input("Enter your choice: "))
+            if choice == 99:
+                break
+            elif 1 <= choice <= len(batches):
+                fetch_batch_details(API_KEY, batches[choice - 1]['id'])
+            else:
+                print("Invalid choice, please try again.")
+        except ValueError:
+            print("Please enter a valid number.")
+
+
+if __name__ == "__main__":
+    main()
+    

--- a/retrieval_batch_job.py
+++ b/retrieval_batch_job.py
@@ -1,0 +1,51 @@
+from openai import OpenAI
+import json
+import argparse
+import requests
+import os
+
+# Set your OpenAI API key
+API_KEY = os.getenv('OPENAI_API_KEY')
+client = OpenAI()
+
+# Function to retrieve batch job results
+def retrieve_batch_job_results(job_id, output_file):
+    try:
+        # Retrieve the job status and details
+        response = client.files.content(job_id)
+        # Get the result data if the job is complete
+        result = response.content
+        results = []
+        for line in result.decode().split('\n'):
+            if line:
+                results.append(json.loads(line))
+        # Save the result to the specified output file
+        with open(output_file, 'w') as f:
+            json.dump(results, f, indent=2)
+        print(f"Results saved to {output_file}")
+    except Exception as e:
+        print(f"Error retrieving job results: {e}")
+
+def fetch_batch_file(api_key, batch_id):
+    """Fetches and displays details of a specific batch."""
+    url = f"https://api.openai.com/v1/batches/{batch_id}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    response = requests.get(url, headers=headers)
+    if response.status_code == 200:
+        batch = response.json()
+        print("Batch Details:")
+        print(batch)
+    else:
+        print("Failed to fetch batch details")
+    return batch['output_file_id']
+
+# Command line interface
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Retrieve batch job results from OpenAI API.")
+    parser.add_argument("job_id", type=str, help="The job ID of the batch job to retrieve results for.")
+    parser.add_argument("output_file", type=str, help="The file to save the results to.")
+    args = parser.parse_args()
+    
+    # Call the function with the provided job ID and output file path
+    file_id = fetch_batch_file(API_KEY, args.job_id)
+    retrieve_batch_job_results(file_id, args.output_file)

--- a/sciriff/eval/eleuther_templates/llama2/_default_template.yaml
+++ b/sciriff/eval/eleuther_templates/llama2/_default_template.yaml
@@ -1,0 +1,14 @@
+group:
+  - science_adapt
+dataset_path: allenai/SciRIFF
+dataset_name: "4096"
+validation_split: validation
+doc_to_text: "<s>[INST] <<SYS>>\nYou are a helpful and honest assistant.\n<</SYS>>\n\n{{ input }} [/INST]"
+doc_to_target: output
+target_delimiter: "\n"
+fewshot_delimiter: "\n\n--------------------\n\n"
+metric_list:
+  - metric: bleu
+    aggregation: mean
+    higher_is_better: true
+    hf_evaluate: true

--- a/sciriff/eval/eleuther_templates/llama2/bioasq_list_qa.yaml
+++ b/sciriff/eval/eleuther_templates/llama2/bioasq_list_qa.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: bioasq_list_qa
+process_docs: !function utils.filter_bioasq_list_qa

--- a/sciriff/eval/eleuther_templates/llama2/biored_ner.yaml
+++ b/sciriff/eval/eleuther_templates/llama2/biored_ner.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: biored_ner
+process_docs: !function utils.filter_biored_ner

--- a/sciriff/eval/eleuther_templates/llama2/discomat_te.yaml
+++ b/sciriff/eval/eleuther_templates/llama2/discomat_te.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: discomat_te
+process_docs: !function utils.filter_discomat_te

--- a/sciriff/eval/eleuther_templates/llama2/evidence_inference.yaml
+++ b/sciriff/eval/eleuther_templates/llama2/evidence_inference.yaml
@@ -1,0 +1,5 @@
+include: _default_template.yaml
+task: evidence_inference
+process_docs: !function utils.filter_evidence_inference
+num_fewshot: 1
+fewshot_delimiter: "\n\n\n"

--- a/sciriff/eval/eleuther_templates/llama2/multicite_intent_classification.yaml
+++ b/sciriff/eval/eleuther_templates/llama2/multicite_intent_classification.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: multicite_intent_classification
+process_docs: !function utils.filter_multicite_intent_classification

--- a/sciriff/eval/eleuther_templates/llama2/mup_single_document_summarization.yaml
+++ b/sciriff/eval/eleuther_templates/llama2/mup_single_document_summarization.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: mup_single_document_summarization
+process_docs: !function utils.filter_mup_single_document_summarization

--- a/sciriff/eval/eleuther_templates/llama2/qasper_abstractive_qa.yaml
+++ b/sciriff/eval/eleuther_templates/llama2/qasper_abstractive_qa.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: qasper_abstractive_qa
+process_docs: !function utils.filter_qasper_abstractive_qa

--- a/sciriff/eval/eleuther_templates/llama2/scierc_ner.yaml
+++ b/sciriff/eval/eleuther_templates/llama2/scierc_ner.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: scierc_ner
+process_docs: !function utils.filter_scierc_ner

--- a/sciriff/eval/eleuther_templates/llama2/scifact_entailment.yaml
+++ b/sciriff/eval/eleuther_templates/llama2/scifact_entailment.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: scifact_entailment
+process_docs: !function utils.filter_scifact_entailment

--- a/sciriff/eval/eleuther_templates/llama2/utils.py
+++ b/sciriff/eval/eleuther_templates/llama2/utils.py
@@ -1,0 +1,23 @@
+from functools import partial
+
+
+def filter_task(ds, task):
+    return ds.filter(lambda inst: inst["_instance_id"].split(":")[0] == task)
+
+
+eval_tasks = [
+    "bioasq_list_qa",
+    "biored_ner",
+    "discomat_te",
+    "evidence_inference",
+    "multicite_intent_classification",
+    "mup_single_document_summarization",
+    "qasper_abstractive_qa",
+    "scierc_ner",
+    "scifact_entailment",
+]
+
+
+for eval_task in eval_tasks:
+    func_name = f"filter_{eval_task}"
+    globals()[func_name] = partial(filter_task, task=eval_task)

--- a/sciriff/eval/eleuther_templates/llama3/_default_template.yaml
+++ b/sciriff/eval/eleuther_templates/llama3/_default_template.yaml
@@ -1,0 +1,14 @@
+group:
+  - science_adapt
+dataset_path: allenai/SciRIFF
+dataset_name: "4096"
+validation_split: validation
+doc_to_text: "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\nCutting Knowledge Date: December 2023\nToday Date: 26 Jul 2024\n\n<|eot_id|><|start_header_id|>user<|end_header_id|>\n\n{{ input }}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+doc_to_target: output
+target_delimiter: "\n"
+fewshot_delimiter: "\n\n--------------------\n\n"
+metric_list:
+  - metric: bleu
+    aggregation: mean
+    higher_is_better: true
+    hf_evaluate: true

--- a/sciriff/eval/eleuther_templates/llama3/bioasq_list_qa.yaml
+++ b/sciriff/eval/eleuther_templates/llama3/bioasq_list_qa.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: bioasq_list_qa
+process_docs: !function utils.filter_bioasq_list_qa

--- a/sciriff/eval/eleuther_templates/llama3/biored_ner.yaml
+++ b/sciriff/eval/eleuther_templates/llama3/biored_ner.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: biored_ner
+process_docs: !function utils.filter_biored_ner

--- a/sciriff/eval/eleuther_templates/llama3/discomat_te.yaml
+++ b/sciriff/eval/eleuther_templates/llama3/discomat_te.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: discomat_te
+process_docs: !function utils.filter_discomat_te

--- a/sciriff/eval/eleuther_templates/llama3/evidence_inference.yaml
+++ b/sciriff/eval/eleuther_templates/llama3/evidence_inference.yaml
@@ -1,0 +1,5 @@
+include: _default_template.yaml
+task: evidence_inference
+process_docs: !function utils.filter_evidence_inference
+num_fewshot: 1
+fewshot_delimiter: "\n\n\n"

--- a/sciriff/eval/eleuther_templates/llama3/multicite_intent_classification.yaml
+++ b/sciriff/eval/eleuther_templates/llama3/multicite_intent_classification.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: multicite_intent_classification
+process_docs: !function utils.filter_multicite_intent_classification

--- a/sciriff/eval/eleuther_templates/llama3/mup_single_document_summarization.yaml
+++ b/sciriff/eval/eleuther_templates/llama3/mup_single_document_summarization.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: mup_single_document_summarization
+process_docs: !function utils.filter_mup_single_document_summarization

--- a/sciriff/eval/eleuther_templates/llama3/qasper_abstractive_qa.yaml
+++ b/sciriff/eval/eleuther_templates/llama3/qasper_abstractive_qa.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: qasper_abstractive_qa
+process_docs: !function utils.filter_qasper_abstractive_qa

--- a/sciriff/eval/eleuther_templates/llama3/scierc_ner.yaml
+++ b/sciriff/eval/eleuther_templates/llama3/scierc_ner.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: scierc_ner
+process_docs: !function utils.filter_scierc_ner

--- a/sciriff/eval/eleuther_templates/llama3/scifact_entailment.yaml
+++ b/sciriff/eval/eleuther_templates/llama3/scifact_entailment.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: scifact_entailment
+process_docs: !function utils.filter_scifact_entailment

--- a/sciriff/eval/eleuther_templates/llama3/utils.py
+++ b/sciriff/eval/eleuther_templates/llama3/utils.py
@@ -1,0 +1,23 @@
+from functools import partial
+
+
+def filter_task(ds, task):
+    return ds.filter(lambda inst: inst["_instance_id"].split(":")[0] == task)
+
+
+eval_tasks = [
+    "bioasq_list_qa",
+    "biored_ner",
+    "discomat_te",
+    "evidence_inference",
+    "multicite_intent_classification",
+    "mup_single_document_summarization",
+    "qasper_abstractive_qa",
+    "scierc_ner",
+    "scifact_entailment",
+]
+
+
+for eval_task in eval_tasks:
+    func_name = f"filter_{eval_task}"
+    globals()[func_name] = partial(filter_task, task=eval_task)

--- a/sciriff/eval/eleuther_templates/qwen/_default_template.yaml
+++ b/sciriff/eval/eleuther_templates/qwen/_default_template.yaml
@@ -1,0 +1,14 @@
+group:
+  - science_adapt
+dataset_path: allenai/SciRIFF
+dataset_name: "4096"
+validation_split: validation
+doc_to_text: "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n{{ input }}<|im_end|>\n<|im_start|>assistant\n"
+doc_to_target: output
+target_delimiter: "\n"
+fewshot_delimiter: "\n\n--------------------\n\n"
+metric_list:
+  - metric: bleu
+    aggregation: mean
+    higher_is_better: true
+    hf_evaluate: true

--- a/sciriff/eval/eleuther_templates/qwen/bioasq_list_qa.yaml
+++ b/sciriff/eval/eleuther_templates/qwen/bioasq_list_qa.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: bioasq_list_qa
+process_docs: !function utils.filter_bioasq_list_qa

--- a/sciriff/eval/eleuther_templates/qwen/biored_ner.yaml
+++ b/sciriff/eval/eleuther_templates/qwen/biored_ner.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: biored_ner
+process_docs: !function utils.filter_biored_ner

--- a/sciriff/eval/eleuther_templates/qwen/discomat_te.yaml
+++ b/sciriff/eval/eleuther_templates/qwen/discomat_te.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: discomat_te
+process_docs: !function utils.filter_discomat_te

--- a/sciriff/eval/eleuther_templates/qwen/evidence_inference.yaml
+++ b/sciriff/eval/eleuther_templates/qwen/evidence_inference.yaml
@@ -1,0 +1,5 @@
+include: _default_template.yaml
+task: evidence_inference
+process_docs: !function utils.filter_evidence_inference
+num_fewshot: 1
+fewshot_delimiter: "\n\n\n"

--- a/sciriff/eval/eleuther_templates/qwen/multicite_intent_classification.yaml
+++ b/sciriff/eval/eleuther_templates/qwen/multicite_intent_classification.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: multicite_intent_classification
+process_docs: !function utils.filter_multicite_intent_classification

--- a/sciriff/eval/eleuther_templates/qwen/mup_single_document_summarization.yaml
+++ b/sciriff/eval/eleuther_templates/qwen/mup_single_document_summarization.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: mup_single_document_summarization
+process_docs: !function utils.filter_mup_single_document_summarization

--- a/sciriff/eval/eleuther_templates/qwen/qasper_abstractive_qa.yaml
+++ b/sciriff/eval/eleuther_templates/qwen/qasper_abstractive_qa.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: qasper_abstractive_qa
+process_docs: !function utils.filter_qasper_abstractive_qa

--- a/sciriff/eval/eleuther_templates/qwen/scierc_ner.yaml
+++ b/sciriff/eval/eleuther_templates/qwen/scierc_ner.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: scierc_ner
+process_docs: !function utils.filter_scierc_ner

--- a/sciriff/eval/eleuther_templates/qwen/scifact_entailment.yaml
+++ b/sciriff/eval/eleuther_templates/qwen/scifact_entailment.yaml
@@ -1,0 +1,3 @@
+include: _default_template.yaml
+task: scifact_entailment
+process_docs: !function utils.filter_scifact_entailment

--- a/sciriff/eval/eleuther_templates/qwen/utils.py
+++ b/sciriff/eval/eleuther_templates/qwen/utils.py
@@ -1,0 +1,23 @@
+from functools import partial
+
+
+def filter_task(ds, task):
+    return ds.filter(lambda inst: inst["_instance_id"].split(":")[0] == task)
+
+
+eval_tasks = [
+    "bioasq_list_qa",
+    "biored_ner",
+    "discomat_te",
+    "evidence_inference",
+    "multicite_intent_classification",
+    "mup_single_document_summarization",
+    "qasper_abstractive_qa",
+    "scierc_ner",
+    "scifact_entailment",
+]
+
+
+for eval_task in eval_tasks:
+    func_name = f"filter_{eval_task}"
+    globals()[func_name] = partial(filter_task, task=eval_task)

--- a/sciriff/eval/metrics/summary_comparison.py
+++ b/sciriff/eval/metrics/summary_comparison.py
@@ -3,10 +3,56 @@ import re
 from openai import OpenAI
 import openai
 import random
+import time, os
 
 # Call judge LLM to compare model answer to reference.
 CLIENT = OpenAI()
 
+
+def create_batch_file(instances, eval_type):
+    tasks = []
+    for idx, instance in enumerate(instances):
+        prompt = make_prompt(instance, eval_type)
+        task = {
+            "custom_id": f"task-{idx}",
+            "method": "POST",
+            "url": "/v1/chat/completions",
+            "body": {
+                # "model": "gpt-4o-mini",
+                "model": "gpt-4o-2024-08-06",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": prompt,
+                    },
+                ],
+            }
+        }
+        tasks.append(task)
+    
+    timestr = time.strftime("%Y%m%d-%H%M%S")
+    os.makedirs("./summary_comparison-logs", exist_ok=True)
+    file_name = f"./summary_comparison-logs/{timestr}-batch_tasks.jsonl"
+    with open(file_name, 'w') as file:
+        for task in tasks:
+            file.write(json.dumps(task) + '\n')
+    
+    return file_name
+
+def submit_batch_job(file_name):
+    batch_file = CLIENT.files.create(
+        file=open(file_name, "rb"),
+        purpose="batch"
+    )
+    
+    batch_job = CLIENT.batches.create(
+        input_file_id=batch_file.id,
+        endpoint="/v1/chat/completions",
+        completion_window="24h"
+    )
+    print(f"Submitted job ID: {batch_job.id}")
+    
+    return batch_job.id
 
 def call_lm_judge(prompt, lm_judge_model):
     chat_completion = CLIENT.chat.completions.create(
@@ -140,10 +186,38 @@ def parse_model_response(response, instance, eval_type):
         instance["decision"] = "error"
 
 
+def batch_lm_judge(instances, eval_type, lm_judge_raw=None):
+    if not lm_judge_raw.exists():
+        file_name = create_batch_file(instances, eval_type)
+        batch_job_id = submit_batch_job(file_name)
+        # results = get_batch_results(batch_job_id)
+        return None
+    else:
+        results = json.load(open(lm_judge_raw))
+    
+    ratings = []
+    for result, instance in zip(results, instances):
+        # response = result['response']['choices'][0]['message']['content']
+        # response = result['response']['body']['choices'][0]['message']['content']
+        # rating = extract_rating(response)
+        # ratings.append(rating)
+        response = result['response']['body']['choices'][0]['message']['content']
+        parse_model_response(response, instance, eval_type)
+        result = instance['decision']
+        if result == 'error':
+            continue
+        if eval_type == "model_comparison":
+            results_encoding = {"win": (1, 1), "tie": (0, 1), "lose": (0, 0)}
+            ratings.append(results_encoding[result])
+        elif eval_type == "reference_comparison":
+            ratings.append(result)
+    return ratings
+
 def lm_judge(instance, eval_type):
-    lm_judge_model = (
-        "gpt-4-turbo-preview" if eval_type == "model_comparison" else "gpt-3.5-turbo"
-    )
+    # lm_judge_model = (
+    #     "gpt-4-turbo-preview" if eval_type == "model_comparison" else "gpt-3.5-turbo"
+    # )
+    lm_judge_model = "gpt-4o-2024-08-06"
     instance["prompt"] = make_prompt(instance, eval_type)
     try:
         response = call_lm_judge(instance["prompt"], lm_judge_model)
@@ -201,11 +275,16 @@ class SummaryComparison:
                     r"Your summary should be (\d+) sentences long", instance["prompt"]
                 ).group(1)
             )
-            results = lm_judge(instance, eval_type="model_comparison")
-            if results:
-                self.scores["lm_judge_n_samples"] += 1
-                self.scores["lm_judge_wins"] += results[0]
-                self.scores["lm_judge_wins_and_ties"] += results[1]
+            # results = lm_judge(instance, eval_type="model_comparison")
+            # if results:
+            #     self.scores["lm_judge_n_samples"] += 1
+            #     self.scores["lm_judge_wins"] += results[0]
+            #     self.scores["lm_judge_wins_and_ties"] += results[1]
+        results = batch_lm_judge(instances.values(), eval_type="model_comparison")
+        for result in results:
+            self.scores["lm_judge_n_samples"] += 1
+            self.scores["lm_judge_wins"] += result[0]
+            self.scores["lm_judge_wins_and_ties"] += result[1]
 
         # calculate win ratio & wins_and_ties ratio
         self.scores["lm_judge_wins"] = (
@@ -217,6 +296,38 @@ class SummaryComparison:
 
         return instances
 
+    def _batch_evaluate_reference_comparison(self, instances, lm_judge_raw):
+        "Have a judge LM grade how well the model's summary matches reference summary, on a scale of 1 to 5."
+        self.scores = {"ratings": []}
+
+        for index, instance in instances.items():
+            instance["title"] = self._extract_data_from_prompt(
+                instance["prompt"], "title"
+            )
+            instance["body_text"] = self._extract_data_from_prompt(
+                instance["prompt"], "body_text"
+            )
+            # results = lm_judge(instance, eval_type="reference_comparison")
+            # if results:
+            #     self.scores["ratings"].append(results)
+        results = batch_lm_judge(instances.values(), eval_type="reference_comparison", lm_judge_raw=lm_judge_raw)
+        if results:
+            # self.scores["ratings"].append(results)
+            self.scores["ratings"] = results
+        else:
+            print("Job submitted. Come back later! ")
+            return None
+
+        # calculate average lm-judge rating
+        self.scores["lm_judge_n_samples"] = len(self.scores["ratings"])
+        self.scores["avg_rating"] = (
+            sum(self.scores["ratings"]) / self.scores["lm_judge_n_samples"]
+        )
+        del self.scores["ratings"]
+        # instances.update(self.scores)
+
+        return instances
+    
     def _evaluate_reference_comparison(self, instances):
         "Have a judge LM grade how well the model's summary matches reference summary, on a scale of 1 to 5."
         self.scores = {"ratings": []}
@@ -248,6 +359,8 @@ class SummaryComparison:
         lm_judge_agg_results_file,
         eval_type,
         n_samples,
+        lm_judge_raw,
+        use_batch_api=False
     ):
 
         # sample n_samples examples for evaluation
@@ -264,7 +377,13 @@ class SummaryComparison:
         if eval_type == "model_comparison":
             filtered_instances = self._evaluate_model_comparison(filtered_instances)
         elif eval_type == "reference_comparison":
-            filtered_instances = self._evaluate_reference_comparison(filtered_instances)
+            if use_batch_api:
+                filtered_instances = self._batch_evaluate_reference_comparison(filtered_instances, lm_judge_raw)
+            else:
+                filtered_instances = self._evaluate_reference_comparison(filtered_instances)
+        
+        if not filtered_instances:
+            return None
 
         # Dump results so we don't need to recompute.
         with open(lm_judge_raw_results_file, ("w")) as f:

--- a/sciriff/eval/tasks/qasper_abstractive_qa.py
+++ b/sciriff/eval/tasks/qasper_abstractive_qa.py
@@ -37,18 +37,22 @@ class Qasper(JSONTask):
             "f1_evidence": res["results"]["all"]["scores"]["f1_evidence_all"],
         }
 
-    def evaluate(self):
+    def evaluate(self, use_batch_api=False):
         res = {}
         predictions, json_counts = self.parse_predictions()
 
         lm_judge_file = self.eval_dir / "lm_judge.json"
+        lm_judge_raw_file = self.eval_dir / "lm_judge_raw.json"
         evaluator = AttributedQAEval()
 
         res["results"] = {}
         res["results"]["valid_json"] = evaluator.evaluate(predictions["parsed"])
         res["results"]["all"] = evaluator.evaluate(
-            predictions["all"], lm_judge_file=lm_judge_file
+            predictions["all"], lm_judge_file=lm_judge_file, lm_judge_raw_file=lm_judge_raw_file, use_batch_api=use_batch_api
         )
+        if use_batch_api and res["results"]["all"] is None:
+            print("Job Sumitted. Check back later!")
+            return
         res["bleu"] = self.get_bleu()
         res["json_counts"] = json_counts
 

--- a/script/eval/predict_eleuther.py
+++ b/script/eval/predict_eleuther.py
@@ -63,6 +63,9 @@ def make_parser():
     parser.add_argument(
         "--limit", type=int, help="Max instances per task.", default=None
     )
+    parser.add_argument(
+        "--apply_chat_template", action='store_true', help="Apply chat template. Default is True."
+    )
     ####################
     # All arguments below this point only apply to Beaker batch jobs; ignore if not
     # AI2-internal.
@@ -180,7 +183,8 @@ def make_task_command(task_name, result_dir, args):
         # If there are already files here, skip it.
         return None
 
-    result_file = result_subdir / "eleuther.jsonl"
+    # result_file = result_subdir / "eleuther.jsonl"
+    result_file = result_subdir
 
     # Get the prompt directory.
     include_path = paths.EVAL_DIR / f"eleuther_templates/{args.chat_template}"
@@ -214,6 +218,12 @@ def make_task_command(task_name, result_dir, args):
     ]
     if args.limit is not None:
         command += ["--limit", args.limit]
+    
+    if args.apply_chat_template is True:
+        if args.chat_template != "general":
+            raise ValueError("Double template config detected. \
+                             If you think you are doing right, comment out at own risk.")
+        command += ["--apply_chat_template"]
 
     return [str(x) for x in command]
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "jsonschema==4.22.0",
         "beaker-py",
         "spacy==3.7.4",
-        "openai==1.33.0",
+        "openai==1.47.0",
         "thefuzz==0.20.0",
         "pytest",
         "tqdm"


### PR DESCRIPTION
 - Add OpenAI batch API feature for cheaper LM judge implementation, along with a few tool scripts to manage batch jobs. 
 - Upgrade `lm-eval` compatibility. Recent models, like Llama 3.2, are supported. `--apply_chat_template` option is available with generic `lm-eval` support. 
 - Push template for Llama and Qwen model families. Note that `--chat_template` should be `general` if `--apply_chat_template` is enabled to prevent double templates. 